### PR TITLE
Steam p2p fix

### DIFF
--- a/lightyear/src/connection/steam/client.rs
+++ b/lightyear/src/connection/steam/client.rs
@@ -124,17 +124,19 @@ impl NetClient for Client {
                 virtual_port,
                 steam_id,
             } => {
-                self.steamworks_client
-                    .read()
-                    .expect("could not get steamworks client")
-                    .get_client()
-                    .networking_sockets()
-                    .connect_p2p(
-                        NetworkingIdentity::new_steam_id(SteamId::from_raw(steam_id)),
-                        virtual_port,
-                        vec![],
-                    )
-                    .context("failed to create p2p connection")?;
+                self.connection = Some(
+                    self.steamworks_client
+                        .read()
+                        .expect("could not get steamworks client")
+                        .get_client()
+                        .networking_sockets()
+                        .connect_p2p(
+                            NetworkingIdentity::new_steam_id(SteamId::from_raw(steam_id)),
+                            virtual_port,
+                            vec![],
+                        )
+                        .context("failed to create p2p connection")?,
+                );
             }
         }
         Ok(())


### PR DESCRIPTION
Set the `client.connection` so that the client actually realizes that it connected successfully.